### PR TITLE
fix: update timeoutId type for Deno 2.8/TS 6.0 setTimeout return type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ Thumbs.db
 # Logs
 logs/
 *.log
+
+# Deepwork session state
+.slim/deepwork/

--- a/packages/client/src/request.client.ts
+++ b/packages/client/src/request.client.ts
@@ -105,7 +105,7 @@ export class RequestClient {
     const method = config.method?.toUpperCase() ?? 'GET';
 
     // Handle timeout
-    let timeoutId: number | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const controller = new AbortController();
     const signal = requestConfig.signal ?? controller.signal;
 


### PR DESCRIPTION
## Problem

`deno task test:unit` and `deno task test:spec` fail type-checking in Deno 2.8.3 / TypeScript 6.0.3. All tests pass at runtime.

```
TS2322 [ERROR]: Type 'Timeout' is not assignable to type 'number'.
      timeoutId = setTimeout(() => {
```

## Root cause

Deno 2.8.3 changed `setTimeout` return type from `number` to `Timeout` object. The variable `timeoutId` was annotated as `number | undefined`.

## Fix

Changed `timeoutId` type annotation to `ReturnType<typeof setTimeout>`, which infers the correct return type from the runtime and works across Deno/TS versions.

**File**: `packages/client/src/request.client.ts:108`

```diff
-    let timeoutId: number | undefined;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
```

## Validation

- `deno task check` — PASS
- `deno task test:unit` — 11/11 PASS
- `deno task test:spec` — 19/19 PASS
- `deno task lint` — PASS
- `deno task fmt:check` — PASS